### PR TITLE
Fix tutorial link at bottom of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ conda install -c conda-forge r-devtools
 
 ## Additional functionality
 
-Some of the additional functionality of our package, including unsupervised learning and multi-omics, is discussed in the [tutorial](https://egr95.github.io/R-codacore/crohn.html). For feature requests, or to get access to an early version, get [in touch](mailto:eg2912@columbia.edu).
+Some of the additional functionality of our package, including unsupervised learning and multi-omics, is discussed in the [tutorial](https://egr95.github.io/R-codacore/guide.html). For feature requests, or to get access to an early version, get [in touch](mailto:eg2912@columbia.edu).


### PR DESCRIPTION
The link at the top of the tutorial worked, but the one at the bottom (which for some reason I tried to click on first :) seemed to be broken. This should fix the link.